### PR TITLE
Updated Resend URL

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -34,5 +34,5 @@ Then **KitForStartups** is for you 🎉!
 - [PostgreSQL](https://www.postgresql.org/) - PostgreSQL is a powerful, open source object-relational database system with over 30 years of active development that has earned it a strong reputation for reliability, feature robustness, and performance.
 - [Stripe](https://stripe.com/) - Stripe is a technology company that builds economic infrastructure for the internet.
 - [Lemon Squeezy](https://lemonsqueezy.io/) - Lemon Squeezy is a Stripe alternative for SaaS businesses.
-- [Resend](https://resend.io/) - Resend is a transactional email service for SaaS businesses.
+- [Resend](https://resend.com/) - Resend is a transactional email service for SaaS businesses.
 - [Mailgun](https://www.mailgun.com/) - Mailgun is an email automation service provided by Rackspace.


### PR DESCRIPTION
The resend website URL has changed from resend.io to resend.com