### PR TITLE
add a note about the env vars needed for email in quick-start

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -89,7 +89,6 @@ The MailHog server will be available at `http://localhost:8025`.
 
 <Note> Remember to update the TRANSACTIONAL\_EMAILS\_\* environment variables in the `.env` file with your sender name and address.</Note>
 
-
 7. Run the app
 
 ```bash

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -47,7 +47,8 @@ For easy local development, there is a `./docker/mysql.yml` file that you can us
 docker-compose -f docker/mysql.yml up -d
 ```
 
-Remember to update the MYSQL\_\* environment variables in the `.env` file with your database credentials.
+> [!NOTE]
+> Remember to update the MYSQL\_\* environment variables in the `.env` file with your database credentials.
 
 5. Run the migrations
 
@@ -86,6 +87,10 @@ docker-compose -f docker/mailhog.yml up -d
 ```
 
 The MailHog server will be available at `http://localhost:8025`.
+
+> [!NOTE]
+> Remember to update the TRANSACTIONAL\_EMAILS\_\* environment variables in the `.env` file with your sender name and address.
+
 
 7. Run the app
 

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -47,8 +47,7 @@ For easy local development, there is a `./docker/mysql.yml` file that you can us
 docker-compose -f docker/mysql.yml up -d
 ```
 
-> [!NOTE]
-> Remember to update the MYSQL\_\* environment variables in the `.env` file with your database credentials.
+<Note>Remember to update the MYSQL\_\* environment variables in the `.env` file with your database credentials.</Note>
 
 5. Run the migrations
 
@@ -88,8 +87,7 @@ docker-compose -f docker/mailhog.yml up -d
 
 The MailHog server will be available at `http://localhost:8025`.
 
-> [!NOTE]
-> Remember to update the TRANSACTIONAL\_EMAILS\_\* environment variables in the `.env` file with your sender name and address.
+<Note> Remember to update the TRANSACTIONAL\_EMAILS\_\* environment variables in the `.env` file with your sender name and address.</Note>
 
 
 7. Run the app


### PR DESCRIPTION
- Mirror the "remember to update ..." for setting up email sending in the quick-start. 
- make the "remember to update ..." alerts/callouts/admonitions (interchangable word usage)

reference: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts