### PR TITLE
Correct turso migrations data folder path

### DIFF
--- a/starter/src/lib/drizzle/turso/drizzle.config.ts
+++ b/starter/src/lib/drizzle/turso/drizzle.config.ts
@@ -10,5 +10,5 @@ export default {
 		url: process.env.TURSO_DB_URL as string,
         authToken: process.env.TURSO_AUTH_TOKEN as string
 	},
-	out: './src/lib/drizzle/migrations/data'
+	out: './src/lib/drizzle/turso/migrations/data'
 } satisfies Config;


### PR DESCRIPTION
Missing `/turso` in the path of drizzle config `out` property causes error when running script `pnpm migrate:turso`.