### PR TITLE
Updated lemon squeezy url

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -33,6 +33,6 @@ Then **KitForStartups** is for you 🎉!
 - [SQLite](https://www.sqlite.org/index.html) - SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine.
 - [PostgreSQL](https://www.postgresql.org/) - PostgreSQL is a powerful, open source object-relational database system with over 30 years of active development that has earned it a strong reputation for reliability, feature robustness, and performance.
 - [Stripe](https://stripe.com/) - Stripe is a technology company that builds economic infrastructure for the internet.
-- [Lemon Squeezy](https://lemonsqueezy.io/) - Lemon Squeezy is a Stripe alternative for SaaS businesses.
+- [Lemon Squeezy](https://lemonsqueezy.com/) - Lemon Squeezy is a Stripe alternative for SaaS businesses.
 - [Resend](https://resend.com/) - Resend is a transactional email service for SaaS businesses.
 - [Mailgun](https://www.mailgun.com/) - Mailgun is an email automation service provided by Rackspace.


### PR DESCRIPTION
- Updated `lemon squeezy` url from https://lemonsqueezy.io/ to https://www.lemonsqueezy.com/